### PR TITLE
Store client cert serials and check serials on connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ conf/openvpn/dh.pem
 conf/openvpn/ta.key
 conf/openvpn/vpn.csr
 conf/openvpn/udp-server.conf
+conf/openvpn/serials/4ab68b294ec8852094e0c1ae8ae6be60cf305b4d
 conf/openvpn/vpn.key
 ````
 

--- a/scripts/check-serial.sh
+++ b/scripts/check-serial.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "${tls_serial_hex_0}" ]; then
+    exit 0;
+fi
+
+SERIAL=`echo "${tls_serial_hex_0}" | sed "s/://g"`
+SERIALDIR=$1
+
+grep "^${X509_0_CN}$" "${SERIALDIR}/${SERIAL}" > /dev/null 2>&1
+
+if [ $? -eq 0 ];
+then
+    echo "Serial ${SERIAL} for ${X509_0_CN} OK";
+else
+    echo "ERROR: Serial ${SERIAL} not found (${X509_0_CN})";
+    exit 1
+fi

--- a/scripts/init-vpn.sh
+++ b/scripts/init-vpn.sh
@@ -3,6 +3,9 @@
 CAKEYFILE="${CADIR}/ca.key"
 CACERTFILE="${CADIR}/ca.crt"
 
+export SERIALDIR="${VPNDIR}/serials"
+mkdir -p ${SERIALDIR}
+
 createKey()
 {
 	local KEYFILE=$1
@@ -103,6 +106,14 @@ createClient()
 
 		envsubst < ${CLIENTCONF} | grep -Ev "^[^=]+=[ ]+$" | openssl req -config - -new -key ${KEYFILE} -out ${CSRFILE}
 		openssl x509 -req -in ${CSRFILE} -CA ${CACERTFILE} -CAkey ${CAKEYFILE} -CAcreateserial -out ${CERTFILE} -days ${CLIENTCERTDAYS:-365} -sha256
+	fi
+
+	# store serial number
+	SERIAL=`openssl x509 -noout -serial -in ${CERTFILE} | sed "s/serial=//" | tr '[:upper:]' '[:lower:]'`
+	SERIALFILE="${SERIALDIR}/${SERIAL}"
+	if [ ! -f ${SERIALFILE} ];
+	then
+		echo "${NAME}" > "${SERIALFILE}"
 	fi
 
 	export CACERT=`cat $CACERTFILE`

--- a/templates/openvpn/server.conf.template
+++ b/templates/openvpn/server.conf.template
@@ -25,3 +25,5 @@ verb 1
 tls-server
 tls-version-min 1.2
 tls-crypt ${VPNTAKEYFILE} 0
+script-security 2
+tls-verify "/check-serial.sh ${SERIALDIR}"


### PR DESCRIPTION
## Release Notes

- Store client certificate serials in OpenVPN `conf/` directory
  - File name equals serial number
  - File content equals certificate CN

````shell
$ find conf/openvpn/serials
conf/openvpn/serials
conf/openvpn/serials/4ab68b294ec8852094e0c1ae8ae6be60cf305b4d
$ cat conf/openvpn/serials/4ab68b294ec8852094e0c1ae8ae6be60cf305b4d
test-client-1
````

- Run **tls-verify** script to check for serial number and certificate CN on connection

```
udp-1  | Serial 4ab68b294ec8852094e0c1ae8ae6be60cf305b4d for test-client-1 OK
```

- To block a client, edit the serial number file and change the name:

````
$ cat conf/openvpn/serials/4ab68b294ec8852094e0c1ae8ae6be60cf305b4d
BLOCKED test-client-1
````

- A missing serial number file will be automatically (re-)created on server start